### PR TITLE
add EventProcessingLock

### DIFF
--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,0 +1,26 @@
+// Global sequential lock for event processing
+export class EventProcessingLock {
+  private currentOperation: Promise<void> = Promise.resolve();
+
+  async withLock<T>(operation: () => Promise<T>): Promise<T> {
+    const execute = async (): Promise<T> => {
+      try {
+        return await operation();
+      } catch (error) {
+        console.error("Event processing error:", error);
+        throw error; // Re-throw to ensure proper error handling
+      }
+    };
+
+    // Queue this operation behind any existing ones
+    const result = this.currentOperation.then(execute);
+
+    // Update the current operation, ensuring cleanup happens
+    this.currentOperation = result.then(
+      () => {}, // Success case
+      () => {}, // Error case - ensure chain continues even after error
+    );
+
+    return result;
+  }
+}


### PR DESCRIPTION
#### Description

Implements an `EventProcessingLock` and use it on `multi_rewards` processor event handlers. This is an attempt at implementing the temporary work around described here https://github.com/sentioxyz/sentio-sdk/issues/1102

However, even with this lock there seems to be a more serious bug in the sentio runtime as event handlers are not being called in the sequence that they were emitted (at least for events within the same transaction).

